### PR TITLE
Do not call configurationWithWriteKey recursively

### DIFF
--- a/Analytics/SEGAnalytics.m
+++ b/Analytics/SEGAnalytics.m
@@ -25,7 +25,10 @@ static SEGAnalytics *__sharedInstance = nil;
 
 + (instancetype)configurationWithWriteKey:(NSString *)writeKey
 {
-    return [[self alloc] initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey]];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return [[self alloc] initWithWriteKey:writeKey];
+#pragma clang diagnostic pop
 }
 
 - (id)initWithWriteKey:(NSString *)writeKey


### PR DESCRIPTION
configureWithWriteKey should be called recursively, this will result in an EXC_BAD_ACCESS crash.  For now suppress the warning.  The problem here is that the method initWithWriteKey is defined twice.